### PR TITLE
Bad error in your security tutorial

### DIFF
--- a/tutorials/security.md
+++ b/tutorials/security.md
@@ -43,6 +43,5 @@ for protocol in ['http', 'https']
 # Trusted sites
 for origin in ['*.google-analytics.com', 'browser-update.org']
   for protocol in ['http', 'https']
-    origin = "#{protocol}://#{origin}"
-    BrowserPolicy.content.allowOriginForAll origin
+    BrowserPolicy.content.allowOriginForAll "#{protocol}://#{origin}"
 ```


### PR DESCRIPTION
In your tutorial on security, you present a coffeescript example for
tuning Browser Policies.
It's published here: http://orionjs.org/tutorials/securing-orion
On te second to last line

``` coffee
origin = "#{protocol}://#{origin}"
```

a variable **origin** is reused. But this is done in a loop! So the
second iteration this will become something like
**https://http://*.example.com** Which is wrong ofcourse...

It would be solved by changing the last 2 line with:

``` coffee
BrowserPolicy.content.allowOriginForAll "#{protocol}://#{origin}"
```
